### PR TITLE
Set event buffer size to correct number

### DIFF
--- a/StPicoMixedEventMaker/StPicoEventMixer.cxx
+++ b/StPicoMixedEventMaker/StPicoEventMixer.cxx
@@ -22,7 +22,7 @@ StPicoEventMixer::StPicoEventMixer(int centBin, int vzBin, int psiBin, StEventPl
    mVzBin = vzBin;
    mPsiBin = psiBin;
    mEventPlaneMaker = eventPlaneMaker;
-   setEventsBufferSize(1);
+   setEventsBufferSize(11);
 
 }
 StPicoEventMixer::~StPicoEventMixer()


### PR DESCRIPTION
@MustafaMustafa  @GuannanXie Found issue, event buffer size was set to 1 so mixing never happened, it had been set to 1 by @HaoQiu for testing. I believe we had already found this bug but forgot to fix.
