### PR TITLE
Fix bug: Set minimum dca to primary vertex 58 microns instead of prev…

### DIFF
--- a/StPicoMixedEventMaker/StMixerCuts.h
+++ b/StPicoMixedEventMaker/StMixerCuts.h
@@ -31,7 +31,7 @@ namespace mxeCuts
    //Tracking
    float const minPt = 0.6;//1.2//0.6
    float const nHitsFit = 20;
-   float const dca2pVtx = 0.008;
+   float const dca2pVtx = 0.0058;
    bool const mRequireHft = true;
    float const Eta = 1.0;
    //PID


### PR DESCRIPTION
…ious 80 micons when filling event buffer
